### PR TITLE
Add titleColor Binder for UIButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ themeService.set(.dark)
 
 ##### UIButton
 - tintColor
+- titleColor
 
 ##### UILabel
 - font

--- a/RxTheme/Classes/Extensions/UIButton+Rx.swift
+++ b/RxTheme/Classes/Extensions/UIButton+Rx.swift
@@ -21,5 +21,14 @@ public extension Reactive where Base: UIButton {
         }
     }
 
+    /// Bindable sink for `titleColor` property
+    public func titleColor(for state: UIControlState) -> Binder<UIColor?> {
+        return Binder(self.base) { view, attr in
+            UIView.animate(withDuration: 0.3, animations: {
+                view.setTitleColor(attr, for: state)
+            })
+        }
+    }
+    
 }
 #endif


### PR DESCRIPTION
I wanted to apply RxTheme to the UIButton's text, but there was no titleColor Binder.
Currently, when we try to change the color of the button's titleLabel, we need to write code like this:
```swift
themeService.relay
    .map{ $0 }
    .subscribe { [weak self] theme in
        let textColor = theme.element?.associatedObject.textColor
        self?.button.setTitleColor(textColor, for: .normal)
        
        let tintColor = theme.element?.associatedObject.tintColor
        self?.button.setTitleColor(tintColor, for: .highlighted)
    }.disposed(by: disposeBag)
```

So I added `titleColor(for state: UIControlState)` Binder.
This binder makes it easier to write code.
```swift
themeService.rx
    .bind({ $0.textColor }, to: button.rx.titleColor(for: .normal))
    .bind({ $0.tintColor }, to: button.rx.titleColor(for: .highlighted))
    .disposed(by: disposeBag)
```